### PR TITLE
72 uiux fix tech icons being fixed size in chrome

### DIFF
--- a/client/src/Landing/Tech.jsx
+++ b/client/src/Landing/Tech.jsx
@@ -1,43 +1,18 @@
-import html from "../assets/how/html.png?web";
-import css from "../assets/how/css.png?web";
-import js from "../assets/how/js.png?web";
-import react from "../assets/how/react.png?web";
-import sql from "../assets/how/sql.png?web";
+import { techIcons } from "./techData";
 
 const Tech = () => {
-  const techIcons = [
-    {
-      id: 0,
-      image: html,
-    },
-    {
-      id: 1,
-      image: css,
-    },
-    {
-      id: 2,
-      image: js,
-    },
-    {
-      id: 3,
-      image: react,
-    },
-    {
-      id: 4,
-      image: sql,
-    },
-  ];
   return (
-    <div id="tech-icons" className="flex">
-      {techIcons.map(({ id, image }) => (
-        <img
-          key={id}
-          src={image}
-          alt={`icon ${id}`}
-          style={{ width: "100%", aspectRatio: "1/1" }}
-        ></img>
+    <ul id="tech-icons" className="flex">
+      {techIcons.map(({ id, image, alt }) => (
+        <li key={id}>
+          <img
+            src={image}
+            alt={alt}
+            style={{ width: "100%", aspectRatio: "1/1" }}
+          ></img>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 };
 

--- a/client/src/Landing/techData.js
+++ b/client/src/Landing/techData.js
@@ -1,0 +1,33 @@
+import html from "../assets/how/html.png?web";
+import css from "../assets/how/css.png?web";
+import js from "../assets/how/js.png?web";
+import react from "../assets/how/react.png?web";
+import sql from "../assets/how/sql.png?web";
+
+export const techIcons = [
+  {
+    id: 0,
+    image: html,
+    alt: "html",
+  },
+  {
+    id: 1,
+    image: css,
+    alt: "css",
+  },
+  {
+    id: 2,
+    image: js,
+    alt: "javascript",
+  },
+  {
+    id: 3,
+    image: react,
+    alt: "react",
+  },
+  {
+    id: 4,
+    image: sql,
+    alt: "react",
+  },
+];


### PR DESCRIPTION
Icons now scaling properly and confirmed working across Firefox, Chrome, and Safari. Prior, it was only Firefox scaling them correctly, because Firefox is awesome and objectively the superior browser.

Also, tech data has been moved to its own file for consistency to reflect social data format.