### PR TITLE
Code to npm install upon deployment.

### DIFF
--- a/.github/workflows/azure-static-web-apps-victorious-plant-0d9bddc10.yml
+++ b/.github/workflows/azure-static-web-apps-victorious-plant-0d9bddc10.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           submodules: true
           lfs: false
+      - name: Install Dependencies
+        run: npm ci
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
After doing...extensive...research on why our Microsoft Azure deployment isn't reflecting the code Greg pushed out, I assumed it could be because the cloud deployment doesn't automatically run "npm install". 

So there is code that automatically runs npm install in our azure workflow file. 